### PR TITLE
Ignore mysql startup failure

### DIFF
--- a/cookbooks/piwik/recipes/default.rb
+++ b/cookbooks/piwik/recipes/default.rb
@@ -53,7 +53,7 @@ end
 # mysql setup
 # HACK: ensure mysql is started in docker after installation
 execute 'mysql_start' do # ~FC004
-  command '/etc/init.d/mysql start'
+  command '/etc/init.d/mysql start || true'
 end
 
 # php-fpm setup


### PR DESCRIPTION
in some cases mysql might already be started and the command fails, which aborts chef client
*Not sure if it might be better to stop and start mysql instead*